### PR TITLE
Update loki backend pySigma version compatibility

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -88,7 +88,7 @@
             "project-url": "https://github.com/grafana/pySigma-backend-loki",
             "report-issue-url": "https://github.com/grafana/pySigma-backend-loki/issues/new",
             "state": "stable",
-            "pysigma-version": "~=0.8.9"
+            "pysigma-version": "~=0.9.0"
         },
         "f2bb108f-d1ec-4e5b-a214-1151ebd99b20": {
             "id": "windows",


### PR DESCRIPTION
The loki backend plugin is compatible with pySigma 0.9+, so updating the version number to reflect this.