### PR TITLE
Update manifest with `ala-sifex` compatability update

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -108,7 +108,7 @@
             "project-url": "https://github.com/sifex/pySigma-backend-azure",
             "report-issue-url": "https://github.com/sifex/pySigma-backend-azure/issues/new",
             "state": "devel",
-            "pysigma-version": "~=0.8.10"
+            "pysigma-version": "~=0.9.6"
         },
         "0bcae3dd-a8fc-4c81-b0ea-203d6176d3de": {
             "id": "stix",


### PR DESCRIPTION
This PR updates the pySigma compatibility from `0.8.10` up to `^0.9.6`. Tests pass, but the package is still in development so state will remained unchanged.