### PR TITLE
Update loki pySigma version support

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -138,7 +138,7 @@
             "project-url": "https://github.com/grafana/pySigma-backend-loki",
             "report-issue-url": "https://github.com/grafana/pySigma-backend-loki/issues/new",
             "state": "stable",
-            "pysigma-version": "~=0.9.0"
+            "pysigma-version": "~=0.10.4"
         },
         "f2bb108f-d1ec-4e5b-a214-1151ebd99b20": {
             "id": "windows",


### PR DESCRIPTION
The [latest version of the loki backend](https://github.com/grafana/pySigma-backend-loki/releases/tag/v0.10.0) now supports pySigma 0.10.4, so update the directory to reflect this.