### PR TITLE
Update supported pysigma-version for multiple EDRs

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -18,7 +18,7 @@
             "project-url": "https://github.com/7RedViolin/pySigma-backend-cortexxdr",
             "report-issue-url":"https://github.com/7RedViolin/pySigma-backend-cortexxdr/issues/new",
             "state": "stable",
-            "pysigma-version": "~=0.9.5"
+            "pysigma-version": ">=0.9.8"
         },
         "f0aa1c83-b406-4ff9-8afa-e5d28e55e074":{
             "id": "carbonblack",
@@ -28,7 +28,7 @@
             "project-url": "https://github.com/7RedViolin/pySigma-backend-carbonblack",
             "report-issue-url":"https://github.com/7RedViolin/pySigma-backend-carbonblack/issues/new",
             "state": "stable",
-            "pysigma-version": "~=0.9.6"
+            "pysigma-version": ">=0.9.6"
         },
         "6f294a42-e43e-11ed-b5ea-0242ac120002": {
             "id": "sentinelone",
@@ -38,7 +38,7 @@
             "project-url": "https://github.com/7RedViolin/pySigma-backend-sentinelone",
             "report-issue-url": "https://github.com/7RedViolin/pySigma-backend-sentinelone/issues/new",
             "state": "stable",
-            "pysigma-version": "~=0.9.5"
+            "pysigma-version": ">=0.9.5"
         },
         "4f57aff1-1144-46d7-b593-21f1d86c358f": {
             "id": "sentinelone-pq",
@@ -48,7 +48,7 @@
             "project-url": "https://github.com/7RedViolin/pySigma-backend-sentinelone-pq",
             "report-issue-url": "https://github.com/7RedViolin/pySigma-backend-sentinelone-pq/issues/new",
             "state": "stable",
-            "pysigma-version": "~=0.9.5"
+            "pysigma-version": ">=0.9.5"
         },
         "4af37b53-f1ec-4567-8017-2fb9315397a1": {
             "id": "splunk",


### PR DESCRIPTION
Changes
- Update supported pysigma-version listed for the following EDRs to match each backend's respective pyproject.toml
  - f7444f11-f49b-4936-984a-a74f192059de: cortexxdr
  - f0aa1c83-b406-4ff9-8afa-e5d28e55e074: carbonblack
  - 6f294a42-e43e-11ed-b5ea-0242ac120002: sentinelone
  - 4f57aff1-1144-46d7-b593-21f1d86c358f: sentinelone-pq