### PR TITLE
Added `pySigma-backend-quickwit` to plugins list

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -279,6 +279,16 @@
             "report-issue-url": "https://github.com/sawwn23/pySigma-backend-trellix-helix/issues/new",
             "state": "devel",
             "pysigma-version": "~=0.11.2"
+        },
+        "3200ecd3-2f32-42ef-90f4-dbe0a66a98e1": {
+            "id": "quickwit",
+            "type": "backend",
+            "description": "Quickwit Backend",
+            "package": "pySigma-backend-quickwit",
+            "project-url": "https://github.com/sifex/pySigma-backend-quickwit/",
+            "report-issue-url": "https://github.com/sifex/pySigma-backend-quickwit/issues/new",
+            "state": "devel",
+            "pysigma-version": "~=0.11.7"
         }
     }
 }


### PR DESCRIPTION
This PR adds the backend `pySigma-backend-quickwit` for adding support for the QuickWit query language documented here: https://quickwit.io/docs/get-started/query-language-intro