### PR TITLE
Update Loki plugin event_count correlation support

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -148,7 +148,10 @@
             "project-url": "https://github.com/grafana/pySigma-backend-loki",
             "report-issue-url": "https://github.com/grafana/pySigma-backend-loki/issues/new",
             "state": "stable",
-            "pysigma-version": "~=0.11.3"
+            "capabilities": [
+                "event_count_correlation_conversion"
+            ],
+            "pysigma-version": "~=0.11.9"
         },
         "f2bb108f-d1ec-4e5b-a214-1151ebd99b20": {
             "id": "windows",


### PR DESCRIPTION
In the latest release (v0.12.0), the pySigma-backend-loki backend has added support for `event_count` correlation rules. This updates the directory to reflect this change and the version of pySigma it uses.