### PR TITLE
Update Loki entry to add value count feature

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -149,7 +149,8 @@
             "report-issue-url": "https://github.com/grafana/pySigma-backend-loki/issues/new",
             "state": "stable",
             "capabilities": [
-                "event_count_correlation_conversion"
+                "event_count_correlation_conversion",
+                "value_count_correlation_conversion"
             ],
             "pysigma-version": "~=0.11.9"
         },

--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -152,7 +152,7 @@
                 "event_count_correlation_conversion",
                 "value_count_correlation_conversion"
             ],
-            "pysigma-version": "~=0.11.9"
+            "pysigma-version": "~=0.11.13"
         },
         "f2bb108f-d1ec-4e5b-a214-1151ebd99b20": {
             "id": "windows",


### PR DESCRIPTION
The latest release of the Loki backend included `value_count` correlation support. This updates the plugin directory to reflect that.