### PR TITLE
update package name for panther

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -268,7 +268,7 @@
             "id": "panther",
             "type": "backend",
             "description": "Panther sdyaml backend",
-            "package": "git+https://github.com/panther-labs/pySigma-backend-panther.git",
+            "package": "pySigma-backend-panther",
             "project-url": "https://github.com/panther-labs/pySigma-backend-panther",
             "report-issue-url": "https://github.com/panther-labs/pySigma-backend-panther/issues/new",
             "state": "devel",


### PR DESCRIPTION
update package name so that the panther package will be installed via pypi instead of from github. this also allows for better dependency management because of available versioning