### PR TITLE
update package name for loki

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -144,7 +144,7 @@
             "id": "loki",
             "type": "backend",
             "description": "Loki backend for conversion into Loki LogQL queries (plain and ruler YAML for alerts) and pipelines with mappings for Grafana and promtail Sysmon data.",
-            "package": "git+https://github.com/grafana/pySigma-backend-loki.git",
+            "package": "pySigma-backend-loki",
             "project-url": "https://github.com/grafana/pySigma-backend-loki",
             "report-issue-url": "https://github.com/grafana/pySigma-backend-loki/issues/new",
             "state": "stable",


### PR DESCRIPTION
update package name so that the loki package will be installed via pypi instead of from github. this also allows for better dependency management because of available versioning