### PR TITLE
Add pySigma-backend-sumologic backend

### DIFF
--- a/pySigma-plugins-v1.json
+++ b/pySigma-plugins-v1.json
@@ -353,6 +353,16 @@
             "report-issue-url": "https://github.com/SigmaHQ/pySigma-pipeline-ocsf/issues/new",
             "state": "stable",
             "pysigma-version": "~=0.11"
+        },
+        "db31f296-7c83-404b-8346-fb2b0ec43a58": {
+            "id": "sumologic",
+            "type": "backend",
+            "description": "Sumo Logic Cloud SIEM backend for converting Sigma rules to CSE detection rules",
+            "package": "pysigma-backend-sumologic",
+            "project-url": "https://github.com/SumoLogic/pySigma-backend-sumologic",
+            "report-issue-url": "https://github.com/SumoLogic/pySigma-backend-sumologic/issues/new",
+            "state": "stable",
+            "pysigma-version": "~=1.0"
         }
     }
 }


### PR DESCRIPTION
## Add pySigma-backend-sumologic backend

- **Backend for:** Sumo Logic Cloud SIEM rule conversion
- **Published to PyPI:** https://pypi.org/project/pysigma-backend-sumologic/
- **Repository:** https://github.com/SumoLogic/pySigma-backend-sumologic
- **All tests passing**
- **Maintainer:** @jc-sumo

### Features
- Converts Sigma rules to complete CSE rule JSON (ready for API import)
- Field mappings for 70+ log sources (Windows, AWS, Azure, GCP, Cisco, Palo Alto, etc.)
- Automatic entity selector assignment per log source category
- MITRE ATT&CK tag mapping
- Confidence scoring for mapping quality validation